### PR TITLE
"Aspiration" wrong machine translation fixed.

### DIFF
--- a/i18n/ru/docusaurus-plugin-content-docs/current/learn/pronunciation.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/learn/pronunciation.md
@@ -27,7 +27,7 @@ origin: http://steen.free.fr/interslavic/pronunciation.html
 - как `ch` на шотландском языке :en[lo**ch**]
 - как `ea` в :en[b**ea**t]
 - как `y` в :en[**y**ard]
-- как `k` по-английски, но без надрыва
+- как `k` по-английски, но без придыхания
 - как `l` на английском языке
 - как `li` в :en[mil**li**on]
 - как `m` в :en[**m**op]


### PR DESCRIPTION
"Надрыв" was replaced by "придыхание" to achieve better accuracy. Phonetic term "aspiration" is always translated as "придыхание" or "аспирация", but never as "надрыв". https://ru.wikipedia.org/wiki/%D0%9F%D1%80%D0%B8%D0%B4%D1%8B%D1%85%D0%B0%D0%BD%D0%B8%D0%B5