### PR TITLE
fix(i18n): correct Polish translation

### DIFF
--- a/i18n/pl/code.json
+++ b/i18n/pl/code.json
@@ -53,7 +53,7 @@
     "message": "Dzięki Międzysłowiańskiemu możesz znaleźć więcej przyjaciół i kolegów mówiących po słowiańsku na całym świecie."
   },
   "pages.home.sections[0].slides[0].title": {
-    "message": "Język zrozumiany przez wszystkie słowiańskie narody"
+    "message": "Język zrozumiały przez wszystkie słowiańskie narody"
   },
   "pages.home.sections[1].actions.primary": {
     "message": "Odkryj więcej"


### PR DESCRIPTION
I'm correcting what I believe was translated automatically.

The difference in meaning is slight, but quite important, as the current text is a bit "odd".

To give you an example:
- [*zrozumiany*](https://pl.wiktionary.org/wiki/zrozumie%C4%87) means that something was understood, like one's feelings can be understood, or someone's speech can be understood, it sounds very unnatural in this context, it's called [imiesłów przymiotnikowy bierny](https://pl.wikipedia.org/wiki/Imies%C5%82%C3%B3w_przymiotnikowy_bierny)
- [*zrozumiały*](https://pl.wiktionary.org/wiki/zrozumia%C5%82y) is just an adjective, means that the language itself can be understand