### PR TITLE
fix the "palatar" typos in phonologyOverview.jsx

### DIFF
--- a/src/markdown/phonology/phonologyOverview.jsx
+++ b/src/markdown/phonology/phonologyOverview.jsx
@@ -10,8 +10,8 @@ export default function PhonologyOverview() {
       <TabItem value="dental/alveolar" label="Dental/alveolar">
         <DentalAlveolar />
       </TabItem>
-      <TabItem value="velar/palata" label="Velar/palatar">
-        <VelarPalatar />
+      <TabItem value="velar/palatal" label="Velar/palatal">
+        <VelarPalatal />
       </TabItem>
       <TabItem value="clusters" label="Clusters">
         <Clusters />
@@ -141,7 +141,7 @@ function DentalAlveolar() {
   )
 }
 
-function VelarPalatar() {
+function VelarPalatal() {
   return (
     <table className="table_sticky">
       <tbody>


### PR DESCRIPTION
it said "velar/palatar" before and the code also had "palata" (sic) in some places so it's fixed now (really hope the `<TabItem value=` parameter isn't expected to be set to `palata` anywhere else)